### PR TITLE
Fix authors syntax in twitter-streaming-importer

### DIFF
--- a/src/main/asciidoc/en/plugins/twitter-streaming-importer-en.adoc
+++ b/src/main/asciidoc/en/plugins/twitter-streaming-importer-en.adoc
@@ -1,5 +1,5 @@
 =  Twitter Streaming Importer
-Clément Levallois <clementlevallois@gmail.com>;Matthieu Totet <matthieu.totet@gmail.com>
+Clément Levallois <clementlevallois@gmail.com>; Matthieu Totet <matthieu.totet@gmail.com>
 2017-01-31
 
 last modified: {docdate}


### PR DESCRIPTION
I've worked on the `asciidoctor-reveal.js` issue you opened at https://github.com/asciidoctor/asciidoctor-reveal.js/issues/122 and noticed there was an error in the syntax